### PR TITLE
Added auth-error page

### DIFF
--- a/src/auth-error.jade
+++ b/src/auth-error.jade
@@ -48,7 +48,7 @@ html
                     .error-key  token ID
                     #token-id.error-value
                   br
-                  a.button.button-primary.button-wide(href='support.mesosphere.com') Get Help
+                  a(class='button button-primary button-wide', href='support.mesosphere.com') Get Help
     script.
       (function(){
         var tracking = getParameterByName('tracking') || 'N/A',


### PR DESCRIPTION
We need to host a generic error page to route users to if Auth0 fails for any reason. Auth0 should always be the referrer.
