### PR TITLE
bump dcos_generate_config.sh download links

### DIFF
--- a/src/releases/1.7.0/index.jade
+++ b/src/releases/1.7.0/index.jade
@@ -10,21 +10,13 @@ block content
 
     .container__content
       h1 DC/OS Release 1.7.0
+      p.hero-subtitle
+        a(href='https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh') Download
+        span &nbsp; &nbsp; &nbsp; &nbsp;
+        a(href='/docs/1.7/') Documentation
 
   .container
     .container__content
-
-      table.releases
-        thead
-          tr
-            th Download
-            th Documentation
-        tbody
-          tr
-            td
-              a.cta.cta--text(href='https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh') dcos_generate_config-1.7.0.sh
-            td
-              a.cta.cta--text(href='/docs/1.7/') /docs/1.7/
 
       h2 Release Notes
       .container__content--release-notes

--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -22,38 +22,41 @@ block content
             .hero-list__item__copy
               h5.hero-list__item__copy__title Stable
               p.hero-list__item__copy__paragraph Latest stable release. Ready for production use.
-              a.cta.cta--text(href='/releases/1.7.0') /releases/1.7.0 &rarr;
+              p(style='margin: 2rem 0 0 0') Coming Soon!
 
           li.hero-list__item
             .hero-list__item__copy
               h5.hero-list__item__copy__title Early Access
               p.hero-list__item__copy__paragraph Upcoming release. Ready for development and testing.
-              a.cta.cta--text(href='/releases/1.7.0') /releases/1.7.0 &rarr;
+              p(style='margin: 1rem 0 0 0') Version: 1.7.0
+              a(style='margin: 0').cta.cta--text(href='/releases/1.7.0') Release Notes &rarr;
+              a(style='margin: 0').cta.cta--text(href='https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh') Download &rarr;
 
           li.hero-list__item
             .hero-list__item__copy
               h5.hero-list__item__copy__title Master
               p.hero-list__item__copy__paragraph Bleeding edge automated release. Only tested with automated tests.
-              a.cta.cta--text(href='/releases/master') /releases/master &rarr;
+              p(style='margin: 2rem 0 0 0') Coming Soon!
 
-      h2 Release Versions
-      table.releases
-        thead
-          tr
-            th Version
-            th Download
-            th Release Notes
-            th Documentation
-        tbody
-          tr
-            td
-              a.cta.cta--text(href='https://github.com/mesosphere/dcos-image/tree/CM.7') 1.7.0
-            td
-              a.cta.cta--text(href='https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh') dcos_generate_config-1.7.0.sh
-            td
-              a.cta.cta--text(href='/releases/1.7.0') /releases/1.7.0
-            td
-              a.cta.cta--text(href='/docs/1.7') /docs/1.7
+      //
+        h2 Release Versions
+        table.releases
+          thead
+            tr
+              th Version
+              th Download
+              th Release Notes
+              th Documentation
+          tbody
+            tr
+              td
+                a.cta.cta--text(href='https://github.com/mesosphere/dcos-image/tree/CM.7') 1.7.0
+              td
+                a.cta.cta--text(href='https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh') dcos_generate_config-EA-1.7.0.sh
+              td
+                a.cta.cta--text(href='/releases/1.7.0') /releases/1.7.0
+              td
+                a.cta.cta--text(href='/docs/1.7') /docs/1.7
 
   .container.container--dark-background
     .container__content


### PR DESCRIPTION
- intermediate styling to remove versions list 

Note: styling changes still pending to match design. This is just content changes.
