### PR TITLE
Drop "big data" from typer.

### DIFF
--- a/src/scripts/typer.js
+++ b/src/scripts/typer.js
@@ -71,5 +71,5 @@
     }
   }
 
-  new Typer($('.typer'), ['containers', 'big data','Spark','Kafka','Cassandra','microservices']);
+  new Typer($('.typer'), ['containers','Spark','Kafka','Cassandra','microservices']);
 })();


### PR DESCRIPTION
The phrase "The easiest way to run big data in production" makes less sense than it could.
