### PR TITLE
Fixed URL to MesosCon website on the community page

### DIFF
--- a/src/community.jade
+++ b/src/community.jade
@@ -174,7 +174,7 @@ block content
               h3.card-title IBM Watson Summit, Tokyo, Japan
               .cta.cta--text More info &rarr;
 
-          a(href='http://conferences.oreilly.com/oscon/' target='_blank').card
+          a(href='http://events.linuxfoundation.org/events/mesoscon-north-america' target='_blank').card
             .card-header(style='background-image: url(/assets/images/events/2016-06-01.jpg)')
               .card-content
                 .card-header__date


### PR DESCRIPTION
Event URL on the Community page for MesosCon was sending users to oscon.com. I've updated the URL to the correct MesosCon website URL.