### PR TITLE
Fixing typos in release notes for virtual networks.

### DIFF
--- a/src/releases/1.8.0/notes.md
+++ b/src/releases/1.8.0/notes.md
@@ -15,7 +15,7 @@ Additionally, you can specify attributes like the time zone or a starting deadli
 
 ## IP per Container with Extensible Virtual Networks (SDN)
 
-DC/OS comes built-in with support Virtual Networks leveraging Container Network Interface (CNI) standard. By default, there is one Virtual Network named `dos` is created and any container that attaches to a Virtual Network, receives its own dedicated IP. This allows users to run workloads that are not friendly to dynamically assigned ports and would rather bind the existing ports that is in their existing app configuration. Now, with support for dedicated IP/Container, workloads are free to bind to any port as every container has access to the entire available port range.
+DC/OS comes built-in with support for Virtual Networks leveraging the Container Network Interface (CNI) standard. By default, there exits one Virtual Network named dcos. Any container that attaches to a virtual network receives its own dedicated IP. This allows users to run workloads that are not friendly to dynamically assigned ports and would rather bind to ports that is in their existing app configuration. Now, with support for dedicated IP/Container, workloads are free to bind to any port as every container has access to the entire available port range.
 
 ## Network Isolation of Virtual Network Subnets
 


### PR DESCRIPTION
The virtual network support is acutally valid for CNI and CNM networks. Should we mention that explicitly ?