### PR TITLE
Fix links in 1.8 blog post

### DIFF
--- a/src/blog/2016-09-15_1.8-ga-release.md
+++ b/src/blog/2016-09-15_1.8-ga-release.md
@@ -10,15 +10,15 @@ lunr: true
 ---
 # Introducing DC/OS 1.8 GA!
 
-On behalf of the DC/OS community and the team at Mesosphere, I’m super excited to let you know that DC/OS 1.8 is in General Availability starting today! This release contains a ton of new open source features, and in case you haven’t had a chance to try them out and contribute comments in any of the [EA releases](releases), below you’ll find a summary of some of the highlights. They include: integrating Marathon and scheduled job support into the DC/OS user interface, upgrading to Mesos 1.0 which provides access to Universal Container Runtime, and Virtual Networks using CNI specs.
+On behalf of the DC/OS community and the team at Mesosphere, I’m super excited to let you know that DC/OS 1.8 is in General Availability starting today! This release contains a ton of new open source features, and in case you haven’t had a chance to try them out and contribute comments in any of the [EA releases][releases], below you’ll find a summary of some of the highlights. They include: integrating Marathon and scheduled job support into the DC/OS user interface, upgrading to Mesos 1.0 which provides access to Universal Container Runtime, and Virtual Networks using CNI specs.
 
-You might notice something new in our documentation starting with DC/OS 1.8: feature maturity tags that tell you how mature and stable a feature is. We’re just rolling these out, so if you have feedback on them, please let us know. And of course feel free to [contribute](contribute) comments or code, especially to experimental and preview features. This release contains features with every maturity tag: experimental, preview, and stable; check out the documentation for each feature to get details.
+You might notice something new in our documentation starting with DC/OS 1.8: feature maturity tags that tell you how mature and stable a feature is. We’re just rolling these out, so if you have feedback on them, please let us know. And of course feel free to [contribute][contribute] comments or code, especially to experimental and preview features. This release contains features with every maturity tag: experimental, preview, and stable; check out the documentation for each feature to get details.
 
 ## Mesos 1.0 and the Universal Container Runtime
 
-With 1.8, DC/OS now uses Mesos 1.0 (released in July; notes [here](mesos-1)), which includes new support for deploying Docker images using the Universal Container Runtime. The Universal Container Runtime lets users take advantage of existing and future Apache Mesos & DC/OS capabilities, including IP per container with CNI support, file-system isolation, and GPU support.
+With 1.8, DC/OS now uses Mesos 1.0 (released in July; notes [here][mesos-1]), which includes new support for deploying Docker images using the Universal Container Runtime. The Universal Container Runtime lets users take advantage of existing and future Apache Mesos & DC/OS capabilities, including IP per container with CNI support, file-system isolation, and GPU support.
 
-The integration of the Universal Container Runtime’s deployment capabilities into DC/OS is experimental. It will give DC/OS users the option to deploy Docker containers with the native Mesos container engine, rather than with the Docker daemon (which will still be available). Please give this feature a try, and feel free to give us [feedback](jira) or squash some bugs yourself; [contributions](contribute) are welcome!
+The integration of the Universal Container Runtime’s deployment capabilities into DC/OS is experimental. It will give DC/OS users the option to deploy Docker containers with the native Mesos container engine, rather than with the Docker daemon (which will still be available). Please give this feature a try, and feel free to give us [feedback][jira] or squash some bugs yourself; [contributions][contribute] are welcome!
 
 ## Access Marathon through “DC/OS Services”
 
@@ -26,7 +26,7 @@ Marathon manages most DC/OS workloads, including stateless containers; Cassandra
 
 ## Built-in DC/OS Scheduled Jobs
 
-We are also bringing native job scheduling capabilities into DC/OS through a new built-in feature, intuitively called “DC/OS Jobs”. Much like what we did for DC/OS Services, you can access DC/OS Jobs from the DC/OS user interface. Don’t forget that you can still install and launch Chronos through the DC/OS Universe! We would love for our users who depend on Chronos to switch over to Jobs, and are happy to help out on the [mailing list](mailing-list) or [Slack](slack) with any migration questions.
+We are also bringing native job scheduling capabilities into DC/OS through a new built-in feature, intuitively called “DC/OS Jobs”. Much like what we did for DC/OS Services, you can access DC/OS Jobs from the DC/OS user interface. Don’t forget that you can still install and launch Chronos through the DC/OS Universe! We would love for our users who depend on Chronos to switch over to Jobs, and are happy to help out on the [mailing list][mailing-list] or [Slack][slack] with any migration questions.
 
 ## IP per Container with Virtual Networks
 
@@ -34,7 +34,7 @@ DC/OS Virtual Networks leverage the Container Network Interface (CNI) standard, 
 
 ## Conclusion
 
-We know a lot of people are excited about the new features in 1.8, including the experimental ones. If you’re one of those excited people, please consider participating in the community! You can get involved by downloading 1.8 [here](releases), reading the [release notes](release-notes), filing any [bugs](jira) you find, checking out the code and, if you find something you want to take on, opening up a PR! If you run into difficulties, or just want to chat, we look forward to seeing you on the [mailing list](mailing-list) or [Slack](slack).
+We know a lot of people are excited about the new features in 1.8, including the experimental ones. If you’re one of those excited people, please consider participating in the community! You can get involved by downloading 1.8 [here][releases], reading the [release notes][release-notes], filing any [bugs][jira] you find, checking out the code and, if you find something you want to take on, opening up a PR! If you run into difficulties, or just want to chat, we look forward to seeing you on the [mailing list][mailing-list] or [Slack][slack].
 
 [releases]: https://dcos.io/releases/
 [contribute]: https://dcos.io/contribute/


### PR DESCRIPTION
The 1.8 release blog post contains invalid Markdown for named references. This corrects the issue.

cc @pyronicide 