### PR TITLE
WIP: Update the release page to point to AWS, Azure

### DIFF
--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -16,7 +16,9 @@ block content
             p.release-version DC/OS 1.8
             p.hero-list__item__copy__paragraph.release-copy Latest stable release. Ready for production use.
             a.cta.cta--text.release-notes(href='/releases/1.8.4/') Release Notes
-            a.cta.cta--button.button--secondary.release-button(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh') Download
+            p.a.cta.cta--button.button--secondary.release-button(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh') Download
+            a.cta.cta--button.button--secondary.release-button(href='https://dcos.io/docs/1.8/administration/installing/cloud/aws/') AWS
+            a.cta.cta--button.button--secondary.release-button(href='https://dcos.io/docs/1.8/administration/installing/cloud/azure/') Azure
         .card.card--inactive
           .card-content
             h3 Early Access
@@ -29,6 +31,8 @@ block content
             p.release-version DC/OS master
             p.hero-list__item__copy__paragraph Bleeding edge automated release. Only tested with automated tests.
             a.cta.cta--button.button--secondary.release-button(href='https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh') Download
+            a.cta.cta--button.button--secondary.release-button(href='https://downloads.dcos.io/dcos/testing/master/aws.html') AWS
+            a.cta.cta--button.button--secondary.release-button(href='https://downloads.dcos.io/dcos/testing/master/azure.html') Azure
       h2.heading-margin-bottom Older Releases
         ul
           li


### PR DESCRIPTION
This has come up from community members several times. That we have CF, Azure ARM, etc. and in many ways if those are usable for a customer use case those should be preferred to using dcos_generate_config.sh

This tries adding links, but soime `position: absolute` stuff makes it so that the buttons aren't all positioned how we want / need (see the attached screenshot). Help fixing would be appreciated.

![image](https://cloud.githubusercontent.com/assets/751088/18602145/057aef4c-7c1c-11e6-9a80-71a2d1ee5c43.png)
