### PR TITLE
removed overlay network redirects

### DIFF
--- a/redirects
+++ b/redirects
@@ -36,7 +36,3 @@
 /docs/1.7/usage/service-discovery/load-balancing-vips/virtual-ip-addresses/index.html /docs/1.7/usage/service-discovery/virtual-ip-addresses/
 /docs/1.8/usage/service-discovery/virtual-ip-addresses/index.html /docs/1.8/usage/service-discovery/load-balancing-vips/virtual-ip-addresses/
 /docs/1.7/usage/jobs/getting-started/index.html /docs/1.8/usage/jobs/getting-started/
-/docs/1.8/administration/overlay-networks/index.html docs/1.8/administration/virtual-networks/
-/docs/1.8/administration/overlay-networks/ip-per-container/index.html docs/1.8/administration/virtual-networks/ip-per-container/
-/docs/1.8/administration/overlay-networks/ip-per-container/isolation/index.html /docs/1.8/administration/virtual-networks/ip-per-container/isolation/
-/docs/1.8/usage/service-discovery/load-balancing-vips/overlay-networks/index.html /docs/1.8/usage/service-discovery/load-balancing-vips/virtual-networks/


### PR DESCRIPTION
need to wait until these pages are published on the OSS docs site