### PR TITLE
Footer changed /brand/ to /brand

### DIFF
--- a/mixins/footer.jade
+++ b/mixins/footer.jade
@@ -13,7 +13,7 @@ mixin footer()
         li.footer-item
           a(href='/releases/') Releases
         li.footer-item
-          a(href='/brand/') Press&nbsp;Kit
+          a(href='/brand') Press&nbsp;Kit
 
       ul.footer-secondary
         li.footer-item


### PR DESCRIPTION
Hi @TimonVS 

Can you help us with a redirect issue? We changed our brand and press kit links to https://brand.ai/mesosphere/mesosphere-brand-guidelines but I can't seem to get the redirects to work.

