### PR TITLE
Add CI/CD demo video

### DIFF
--- a/src/demos.jade
+++ b/src/demos.jade
@@ -51,6 +51,7 @@ block content
             p Demo of a CI/CD pipeline using Jenkins
             .card__links
               a(href='https://github.com/mesosphere/cd-demo').cta.cta--text GitHub
+              a(href='https://www.youtube.com/watch?v=cnIfSrMxgyE').cta.cta--text Video
 
         .card.demo-card
           .card-header(style='background-image: url(/assets/images/demos/github-stream.png)')


### PR DESCRIPTION
## What are your changes?

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [x] I have built locally and tested for broken links and formatting.
- [N/A] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:

Adding the CI/CD demo video from our workshop at VelocityConf 2016 in
NYC.

/cc @mhausenblas, @ssk2