### PR TITLE
FIX: version dropdown not being visible sometimes

### DIFF
--- a/src/scripts/docs.js
+++ b/src/scripts/docs.js
@@ -88,8 +88,8 @@
     let docsArticleHeight = docsArticle.outerHeight();
     let newDocsNavHeight;
 
-    if (docsNavHeight < docsArticleHeight) newDocsNavHeight = docsArticleHeight;
-    else newDocsNavHeight = docsNavHeight + 40;
+    if (docsNavHeight < docsArticleHeight) newDocsNavHeight = docsArticleHeight + 40;
+    else newDocsNavHeight = docsNavHeight + 80;
 
     docsNav.css({height: `${newDocsNavHeight}px`});
   }

--- a/src/styles/_docs.scss
+++ b/src/styles/_docs.scss
@@ -573,4 +573,5 @@ img.docs-content__footer__share-icon {
 
 .docs-version-select {
   width: calc(100% - 60px) !important;
+  flex-shrink: 0;
 }


### PR DESCRIPTION
## What are your changes?

Fix a bug where the version dropdown was sometimes empty.

## What is the urgency level of this change?
- [x] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [x] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:

