### PR TITLE
Hide events carousel arrow when there are no events

### DIFF
--- a/src/community.jade
+++ b/src/community.jade
@@ -59,11 +59,12 @@ block content
   .container.events-container
     .container__content
       .events-carousel
-        .events-carousel-btn.events-carousel-btn--next
-          img(src='/assets/images/icons/chevron-dark-right.svg')
+        if (locals.events.length)
+          .events-carousel-btn.events-carousel-btn--next
+            img(src='/assets/images/icons/chevron-dark-right.svg')
 
-        .events-carousel-btn.events-carousel-btn--prev
-          img(src='/assets/images/icons/chevron-dark-left.svg')
+          .events-carousel-btn.events-carousel-btn--prev
+            img(src='/assets/images/icons/chevron-dark-left.svg')
 
         .card-container
           each event in locals.events


### PR DESCRIPTION
## What are your changes?

Hide the events carousel arrow when there are no events.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [x] Medium

## I have completed these items:
- [x] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:

https://dcosjira.atlassian.net/projects/SITE/issues/SITE-77