### PR TITLE
Fixed dcos.io/brand link

### DIFF
--- a/src/brand.jade
+++ b/src/brand.jade
@@ -1,4 +1,4 @@
 doctype html
 html
   head
-    meta(http-equiv='refresh', content="0; url=https://dcos.io/brand")
+    meta(http-equiv='refresh', content="0; url=https://brand.ai/mesosphere/dc-os-brand-guidelines")


### PR DESCRIPTION
## What are your changes?
Fixing brand redirect link

## What is the urgency level of this change?
- [X] High

## I have completed these items:
- [X] I have built locally and tested for broken links and formatting.

## If you included a comment with your commit, it appears here:

I fixed the dcoi.io/brand link to now redirect to brand.ai page.