### PR TITLE
Docs dropdown version order

### DIFF
--- a/layouts/docs.jade
+++ b/layouts/docs.jade
@@ -46,6 +46,8 @@ include ../mixins/head.jade
     return string.charAt(0).toUpperCase() + string.slice(1)
   }
 
+  var docsVersionsReversed = docsVersions.slice().reverse()
+
 mixin icon(child)
   if(child.type === 'dir')
     if(findPath(child.name))
@@ -121,10 +123,9 @@ html
               input(type='search').docs-search__input
 
             select(name="docs-version").docs-version-select.dropdown#docs-version-select Select version
-              option(selected, value="#{docsVersion}") DC/OS #{docsVersion}
-              each version in docsVersions
-                if (version != docsVersion)
-                  option(value="#{version}") DC/OS #{version}
+              each version in docsVersionsReversed
+                //- empty string will add the `selected` attribute, `undefined` will _not_ add the selected attribute
+                option(selected=(version === docsVersion ? "" : undefined), value="#{version}") DC/OS #{version}
 
             +renderMenu(locals.navs.header).docs-menu
 


### PR DESCRIPTION
## What are your changes?

Fixed the order of versions in the docs version dropdown.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:

Please merge #982 first before merging this PR ⚠️.