### PR TITLE
Fixed z-index on the “get release” button

### DIFF
--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -22,7 +22,7 @@ block content
             a.cta.cta--text.release-notes.pb2(href='/releases/1.8.7/') Release Notes
 
             .col-12.flex-end.mt-auto.relative
-              button.absolute.dropdown(style='text-align: left; left: 0; width: 100%;')
+              button.absolute.dropdown.z-500(style='text-align: left; left: 0; width: 100%;')
                 a.btn.btn-primary.mb0.block.center.no-arrow Get Release
                   img.ml1.align-middle(src='/assets/images/icons/arrow-down-docs-unselected-white.svg' style='margin-top: -2px;')
                 ul
@@ -46,7 +46,7 @@ block content
               p.hero-list__item__copy__paragraph.release-copy.pb2 Bleeding edge automated release. Only tested with automated tests.
 
               .col-12.flex-end.mt-auto.relative
-                button.absolute.dropdown(style='text-align: left; left: 0; width: 100%;')
+                button.absolute.dropdown.z-500(style='text-align: left; left: 0; width: 100%;')
                   a.btn.btn-primary.mb0.block.center.no-arrow Get Release
                     img.ml1.align-middle(src='/assets/images/icons/arrow-down-docs-unselected-white.svg' style='margin-top: -2px;')
                   ul

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -93,6 +93,8 @@
 
 .mt-auto { margin-top: auto; }
 
+.z-500 { z-index: 500; }
+
 @media screen and (max-width: 40rem) {
   .xs-col-12 {
     width: 100%;


### PR DESCRIPTION
## What are your changes?
Added an overwrite for the z-index in order to fix a small bug on mobile on the get release dropdown.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.
