### PR TITLE
Show dev version in dropdown (docs)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,8 @@ const buffer = require('vinyl-buffer')
 //
 
 const docsVersions = ['1.7', '1.8', '1.9']
+const currentDevVersion = '1.9'
+
 const cssTimestamp = new Date().getTime()
 const paths = {
   build: './build',
@@ -205,7 +207,7 @@ function getDocsBuildTask (version) {
       }))
       .pipe(
         gulpsmith()
-          .metadata({ docsVersion: version, docsVersions })
+          .metadata({ docsVersion: version, docsVersions, currentDevVersion })
           .use(addTimestampToMarkdownFiles)
           .use(markdown({
             smartypants: true,
@@ -221,7 +223,7 @@ function getDocsBuildTask (version) {
           }))
           .use(each(updatePaths))
           .use(jade({
-            locals: { cssTimestamp, docsVersions },
+            locals: { cssTimestamp, docsVersions, currentDevVersion },
             useMetadata: true,
             pretty: true
           }))

--- a/layouts/docs.jade
+++ b/layouts/docs.jade
@@ -125,7 +125,7 @@ html
             select(name="docs-version").docs-version-select.dropdown#docs-version-select Select version
               each version in docsVersionsReversed
                 //- empty string will add the `selected` attribute, `undefined` will _not_ add the selected attribute
-                option(selected=(version === docsVersion ? "" : undefined), value="#{version}") DC/OS #{version}
+                option(selected=(version === docsVersion ? "" : undefined), value="#{version}") DC/OS #{(version === currentDevVersion ? `${version} Development` : version)}
 
             +renderMenu(locals.navs.header).docs-menu
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -16,6 +16,9 @@ require('./typer.js')
 import Wallop from 'wallop';
 import Hammer from 'hammerjs';
 
+const compareVersions = require('compare-versions');
+window.compareVersions = compareVersions;
+
 // Mobile menu
 $('#nav-icon').on('click', function (e) {
   e.preventDefault();


### PR DESCRIPTION
## What are your changes?
Added 'development' to 1.9 in the dropdown.
<img width="381" alt="screen shot 2016-12-06 at 12 05 40" src="https://cloud.githubusercontent.com/assets/4411144/20923371/580997c0-bbac-11e6-9795-fbb0f7a7976f.png">

I suggest changing the design of this dropdown to the one I made for releases though, same goes for the dropdown on blog. (I wouldn't do this right away, because I think some issues on Jira have a higher priority).
<img width="348" alt="screen shot 2016-12-06 at 12 06 35" src="https://cloud.githubusercontent.com/assets/4411144/20923397/7c5fe368-bbac-11e6-8d24-cfce5e66b775.png">

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:
I added a const in the gulp file that indicates the current ‘dev’ version.