### PR TITLE
Fix for ‘In This Post sidebar nav runs over the main page’

### DIFF
--- a/src/scripts/docs.js
+++ b/src/scripts/docs.js
@@ -130,4 +130,9 @@ $(document).ready(() => {
 
   calculateDocsNavHeight();
   $('.docs-nav__item a').on('click', calculateDocsNavHeight);
+
+  // in this post width fix
+  $('.scroll-nav').width($('nav.docs-in-this-post').width());
+
+
 })


### PR DESCRIPTION
## What are your changes?
The plugin @TimonVS used applied `position: fixed` to the nav which resulted in the element to ignore the width of its parent. I used Javascript to solve this issue.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.