### PR TITLE
Feature/author profiles blog

### DIFF
--- a/layouts/article.jade
+++ b/layouts/article.jade
@@ -33,7 +33,7 @@ block content
     .container__content.blog-article-wrapper
       .post-meta
         if locals.author_url
-          a.post-meta__author(href=author_url)!= author
+          a.post-meta__author(href=author_url, target='_blank')!= author
         else
           .post-meta__author!= author
 

--- a/layouts/article.jade
+++ b/layouts/article.jade
@@ -32,8 +32,11 @@ block content
   .container
     .container__content.blog-article-wrapper
       .post-meta
-        //.post-meta__author!= author
-        a.post-meta__author(href=author_url)!= author
+        if locals.author_url
+          a.post-meta__author(href=author_url)!= author
+        else
+          .post-meta__author!= author
+
         .post-meta__date= moment(date).format("MMM Do, YYYY")
         .post-divider
 

--- a/layouts/article.jade
+++ b/layouts/article.jade
@@ -32,7 +32,8 @@ block content
   .container
     .container__content.blog-article-wrapper
       .post-meta
-        .post-meta__author!= author
+        //.post-meta__author!= author
+        a.post-meta__author(href=author_url)!= author
         .post-meta__date= moment(date).format("MMM Do, YYYY")
         .post-divider
 

--- a/src/blog/2016-06-15_wellframe.md
+++ b/src/blog/2016-06-15_wellframe.md
@@ -2,6 +2,7 @@
 title: How healthcare startup Wellframe simplifies ops with DC/OS
 date: 2016-06-15
 author: Jeffrey Warren, Wellframe
+author_url: https://github.com/jtwarren
 category: usage
 description: The journey of Wellframe, moving from vanilla Apache Mesos to DC/OS and which benefits they witnessed.
 layout: article.jade

--- a/src/blog/2016-06-15_wellframe.md
+++ b/src/blog/2016-06-15_wellframe.md
@@ -2,7 +2,6 @@
 title: How healthcare startup Wellframe simplifies ops with DC/OS
 date: 2016-06-15
 author: Jeffrey Warren, Wellframe
-author_url: https://github.com/jtwarren
 category: usage
 description: The journey of Wellframe, moving from vanilla Apache Mesos to DC/OS and which benefits they witnessed.
 layout: article.jade


### PR DESCRIPTION
## What are your changes?
Show the author name as a link by adding `author_url` to the frontmatter of each markdown file for the blog.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.