### PR TITLE
Removed 1.9 download button

### DIFF
--- a/src/releases/1.9.0/index.jade
+++ b/src/releases/1.9.0/index.jade
@@ -12,7 +12,7 @@ block content
     .container__content
       h1 DC/OS Release 1.9.0
       p.hero-subtitle
-        a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh').cta.cta--button Download
+        <! -- a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh').cta.cta--button Download -->
         a(href='/docs/1.9/').cta.cta--text View Documentation &rarr;
 
   .container


### PR DESCRIPTION
## What are your changes?

## What is the urgency level of this change?
- [x] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [x] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:
