### PR TITLE
Docs version switch

### DIFF
--- a/layouts/docs.jade
+++ b/layouts/docs.jade
@@ -140,7 +140,7 @@ html
                 a.btn.mb0.block DC/OS #{(docsVersion === currentDevVersion ? `${docsVersion} Development` : docsVersion)}
                 ul
                   each version in docsVersionsReversed
-                    li: a(href='/docs/#{version}', class=(version === docsVersion ? "text-heliotrope current" : undefined)) DC/OS #{(version === currentDevVersion ? `${version} Development` : version)}
+                    li: a(href='/docs/#{version}', data-version='#{version}', class=(version === docsVersion ? 'text-heliotrope current option' : 'option')) DC/OS #{(version === currentDevVersion ? `${version} Development` : version)}
 
 
             +renderMenu(locals.navs.header).docs-menu

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -177,3 +177,30 @@ const jDescription = `Source: ${window.location.href}` // description
 const jLabels = 'documentation'
 
 $('#submit-feedback').attr('href', `https://dcosjira.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=${jPid}&issuetype=${jIssueType}&summary=${jSummary}&description=${jDescription}&labels=${jLabels}`)
+
+
+/****************
+  Docs version switch 404 prevention
+****************/
+
+const currentUrlPath = window.location.pathname
+var pathArray = currentUrlPath.split('/')
+
+$('button.dropdown a.option').click(function(event){
+  event.preventDefault()
+  pathArray[2] = $(this).attr('data-version')
+  var newUrlPath = window.location.origin + pathArray.join('/')
+
+  $.ajax({
+      type: "HEAD",
+      async: true,
+      url: newUrlPath,
+      success: function(message){
+        location.assign(newUrlPath)
+      },
+      error: function(message){
+        location.assign(`${window.location.origin}/docs/${pathArray[2]}`)
+      }
+  })
+
+})


### PR DESCRIPTION
## What are your changes?
Docs version switch now opens the same page when switching docs versions. 404 are prevented by doing an ajax call and check for 404 errors. People are redirected to the version root when the requested page doesn’t exist.

## What is the urgency level of this change?
- [ ] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.