### PR TITLE
Fix contribute to docs link

### DIFF
--- a/src/contribute.jade
+++ b/src/contribute.jade
@@ -16,7 +16,7 @@ block content
       .text-align-left
         
         h2 Contributing content
-        p If you plan to create content around DC/OS, for example a demo, a tutorial, a video, an article or anything that is not directly a code contribution to DC/OS, have a look at #[a(href='https://github.com/dcos/dcos-docs/blob/master/CONTRIBUTING.md') how to contribute to the docs], let us know via #[a(href='http://chat.mesosphere.com/?_ga=1.264992783.1471453052.1460758981') Slack] or ping us via  #[a(href='mailto:help@dcos.io') help@dcos.io].
+        p If you plan to create content around DC/OS, for example a demo, a tutorial, a video, an article or anything that is not directly a code contribution to DC/OS, have a look at #[a(href='https://github.com/dcos/dcos-docs/#contributing') how to contribute to the docs], let us know via #[a(href='http://chat.mesosphere.com/?_ga=1.264992783.1471453052.1460758981') Slack] or ping us via  #[a(href='mailto:help@dcos.io') help@dcos.io].
 
         h2 Publishing services
         p In addition to the services currently #[a(href='https://dcos.io/docs/1.7/development/') published] you're welcome to publish your own service. If you're unsure how to proceed, send us an email via #[a(href='mailto:universe@dcos.io') universe@dcos.io] and we will take it from there.


### PR DESCRIPTION
The old link went to a contributing page that no longer exists, update to point to the section of the dcos-docs repository readme that now contains the contributing documentation.
