### PR TITLE
Link to 1.8 development docs page

### DIFF
--- a/src/contribute.jade
+++ b/src/contribute.jade
@@ -19,7 +19,7 @@ block content
         p If you plan to create content around DC/OS, for example a demo, a tutorial, a video, an article or anything that is not directly a code contribution to DC/OS, have a look at #[a(href='https://github.com/dcos/dcos-docs/blob/master/CONTRIBUTING.md') how to contribute to the docs], let us know via #[a(href='http://chat.mesosphere.com/?_ga=1.264992783.1471453052.1460758981') Slack] or ping us via  #[a(href='mailto:help@dcos.io') help@dcos.io].
 
         h2 Publishing services
-        p In addition to the services currently #[a(href='https://dcos.io/docs/1.7/development/') published] you're welcome to publish your own service. If you're unsure how to proceed, send us an email via #[a(href='mailto:universe@dcos.io') universe@dcos.io] and we will take it from there.
+        p In addition to the services currently #[a(href='https://dcos.io/docs/1.8/development/') published] you're welcome to publish your own service. If you're unsure how to proceed, send us an email via #[a(href='mailto:universe@dcos.io') universe@dcos.io] and we will take it from there.
 
         include:markdown code-contrib.md
 

--- a/src/contribute.jade
+++ b/src/contribute.jade
@@ -19,7 +19,7 @@ block content
         p If you plan to create content around DC/OS, for example a demo, a tutorial, a video, an article or anything that is not directly a code contribution to DC/OS, have a look at #[a(href='https://github.com/dcos/dcos-docs/blob/master/CONTRIBUTING.md') how to contribute to the docs], let us know via #[a(href='http://chat.mesosphere.com/?_ga=1.264992783.1471453052.1460758981') Slack] or ping us via  #[a(href='mailto:help@dcos.io') help@dcos.io].
 
         h2 Publishing services
-        p In addition to the services currently #[a(href='https://dcos.io/docs/1.8/development/') published] you're welcome to publish your own service. If you're unsure how to proceed, send us an email via #[a(href='mailto:universe@dcos.io') universe@dcos.io] and we will take it from there.
+        p In addition to the services currently #[a(href='https://dcos.io/docs/latest/development/') published] you're welcome to publish your own service. If you're unsure how to proceed, send us an email via #[a(href='mailto:universe@dcos.io') universe@dcos.io] and we will take it from there.
 
         include:markdown code-contrib.md
 


### PR DESCRIPTION
The contribute page was linking to the development page for the 1.7 release, update to 1.8.
