### PR TITLE
Add 1.8.7 hash for download

### DIFF
--- a/src/releases/1.8.7/index.jade
+++ b/src/releases/1.8.7/index.jade
@@ -12,7 +12,7 @@ block content
     .container__content
       h1 DC/OS Release 1.8.7
       p.hero-subtitle
-        a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh').cta.cta--button Download
+        a(href='https://downloads.dcos.io/dcos/stable/commit/1b43ff7a0b9124db9439299b789f2e2dc3cc086c/dcos_generate_config.sh').cta.cta--button Download
         a(href='/docs/1.8/').cta.cta--text View Documentation &rarr;
 
   .container


### PR DESCRIPTION
## What are your changes?
- Added link to 1.8.7 download.
- https://jira.mesosphere.com/browse/DCOS-13980
## What is the urgency level of this change?
- [x] Blocker
- [ ] High
- [ ] Medium

## I have completed these items:
- [ ] I have built locally and tested for broken links and formatting.
- [ ] If appropriate, I have added redirects.

## If you included a comment with your commit, it appears here:
