### PR TITLE
Fix download links

### DIFF
--- a/src/releases/1.9.0/index.jade
+++ b/src/releases/1.9.0/index.jade
@@ -12,7 +12,7 @@ block content
     .container__content
       h1 DC/OS Release 1.9.0
       p.hero-subtitle
-        a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh').cta.cta--button Download
+        a(href='https://downloads.dcos.io/dcos/EarlyAccess/commit/26d16366a29aba258541a8653b00522c4c1c21fc/dcos_generate_config.sh').cta.cta--button Download
         a(href='/docs/1.9/').cta.cta--text View Documentation &rarr;
 
   .container

--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -26,8 +26,8 @@ block content
                 a.btn.btn-primary.mb0.block.center.no-arrow.text-white.bg-heliotrope Get Release
                   img.ml1.align-middle(src='/assets/images/icons/arrow-down-docs-unselected-white.svg' style='margin-top: -2px;')
                 ul
-                  li: a(href='https://dcos.io/docs/1.8/administration/installing/cloud/aws/') Amazon Web Services
-                  li: a(href='https://dcos.io/docs/1.8/administration/installing/cloud/azure/') Azure
+                  li: a(href='https://downloads.dcos.io/dcos/stable/aws.html', target='_blank') Amazon Web Services
+                  li: a(href='https://downloads.dcos.io/dcos/stable/azure.html', target='_blank') Azure
                   li: a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh') Direct Download
 
           .card.card-content.stable.col-4.relative(style="justify-content: inherit; padding-bottom: 3.75rem;")
@@ -41,9 +41,9 @@ block content
                 a.btn.btn-primary.mb0.block.center.no-arrow.text-white.bg-heliotrope Get Release
                   img.ml1.align-middle(src='/assets/images/icons/arrow-down-docs-unselected-white.svg' style='margin-top: -2px;')
                 ul
-                  li: a(href='https://dcos.io/docs/1.9/administration/installing/cloud/aws/') Amazon Web Services
-                  li: a(href='https://dcos.io/docs/1.9/administration/installing/cloud/azure/') Azure
-                  li: a(href='https://downloads.dcos.io/dcos/EarlyAccess/commit/26d16366a29aba258541a8653b00522c4c1c21fc/dcos_generate_config.sh') Direct Download
+                  li: a(href='https://downloads.dcos.io/dcos/EarlyAccess/aws.html', target='_blank') Amazon Web Services
+                  li: a(href='https://downloads.dcos.io/dcos/EarlyAccess/azure.html', target='_blank') Azure
+                  li: a(href='https://downloads.dcos.io/dcos/EarlyAccess/dcos_generate_config.sh') Direct Download
 
           .master-releases.card.card-content.stable.col-4.relative(style="justify-content: inherit; padding-bottom: 3.75rem;")
             h3.mb0 Master
@@ -55,8 +55,8 @@ block content
                 a.btn.btn-primary.mb0.block.center.no-arrow.text-white.bg-heliotrope Get Release
                   img.ml1.align-middle(src='/assets/images/icons/arrow-down-docs-unselected-white.svg' style='margin-top: -2px;')
                 ul
-                  li: a(href='https://downloads.dcos.io/dcos/testing/master/aws.html') Amazon Web Services
-                  li: a(href='https://downloads.dcos.io/dcos/testing/master/azure.html') Azure
+                  li: a(href='https://downloads.dcos.io/dcos/testing/master/aws.html', target='_blank') Amazon Web Services
+                  li: a(href='https://downloads.dcos.io/dcos/testing/master/azure.html', target='_blank') Azure
                   li: a(href='https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh') Direct Download
 
 


### PR DESCRIPTION
## Description
- Fix download links
- Change releases page to link directly to generated aws/azure templates instead of the docs
- Make template pages open in a new window.

## Urgency
- [X] Blocker
- [ ] High
- [ ] Medium
