### PR TITLE
1.9 version picker

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ const excerpts = require('metalsmith-excerpts')
 //
 
 const docsVersions = ['1.7', '1.8', '1.9']
-const currentDevVersion = '1.9'
+const currentDevVersion = '1.10'
 
 const cssTimestamp = new Date().getTime()
 const paths = {

--- a/redirect-prefixes
+++ b/redirect-prefixes
@@ -1,4 +1,4 @@
-/docs/latest/ /docs/1.8/
+/docs/latest/ /docs/1.9/
 /documentation/ /docs/latest/
 /support/ /community/
 /docs/overview/ /docs/latest/overview/


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/DOCS-1692
- adds placeholder for 1.10 early access
- make 1.9 the default version

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
