### PR TITLE
[blocked] Update builder to use Alpine

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -1,29 +1,6 @@
-FROM debian:jessie
+FROM mhart/alpine-node:6.10.1
 
-RUN set -ex \
-  && for key in \
-    9554F04D7259F04124DE6B476D5A82AC7E37093B \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    0034A06D9D9B0064CE8ADF6BF1747F4AD2306D93 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-  ; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done \
-  && apt-get update && apt-get install -y git curl xz-utils
-
-ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 5.11.0
-
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
-  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
+RUN apk --no-cache add git curl xz bash python
 
 VOLUME /dcos-website
 WORKDIR /dcos-website

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM mhart/alpine-node:6.10.1
 
-RUN apk --no-cache add git curl xz bash python
+RUN apk --no-cache add git curl xz bash python make g++
 
 VOLUME /dcos-website
 WORKDIR /dcos-website

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,5 +13,4 @@ set -x
 export NODE_UNICODETABLE_UNICODEDATA_TXT="$(pwd)/UnicodeData.txt"
 
 npm install
-npm rebuild node-sass
 CI=true npm test


### PR DESCRIPTION
## Description
Updating the builder to use alpine will reduce build times on CI.

Unfortunately, this is blocked because one of the dependencies (`basscss-sass`) requires an old version (`3.13.1`) of node-sass which has a postinstall hook that doesn't work on alpine until `4.1.0+`. 
Bug: https://github.com/basscss/basscss-sass/issues/16
Related: https://github.com/sass/node-sass/issues/1589

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [X] High
- [ ] Medium
