### PR TITLE
Changed 101 tutorial from Get Started to 1.8

### DIFF
--- a/src/get-started.jade
+++ b/src/get-started.jade
@@ -57,7 +57,7 @@ block content
               li Investigating/debugging common problems
 
           .col-12.px2.pt2.center
-            a(href='https://dcos.io/docs/latest/usage/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
+            a(href='https://dcos.io/docs/1.8/usage/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
 
 
 


### PR DESCRIPTION
## Description
<!-- Link to JIRA issue -->
101 tutorial is not yet merged for 1.9 (https://github.com/dcos/dcos-docs/pull/947). Hard-coding to 1.8 for now.

## Urgency
- [x] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
