### PR TITLE
updates gulp-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.1.1",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "^3.0.0",
     "gulp-uglify": "^1.5.4",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.9",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,6 @@
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-navigation": "davidvanleeuwen/metalsmith-navigation",
     "metalsmith-permalinks": "^0.5.0",
-    "metalsmith-postcss": "^3.1.0",
-    "metalsmith-sass": "^1.3.0",
     "metalsmith-tags": "^1.2.1",
     "metalsmith-writemetadata": "^0.4.5",
     "moment": "^2.13.0",


### PR DESCRIPTION
This means we’re now using node-sass 4.2. Please run npm-install and check thoroughly, but all seems to be fine on our end.

## Description
https://jira.mesosphere.com/browse/DCOS_SITE-197

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).