### PR TITLE
Link to 1.9 docs on Getting Started page

### DIFF
--- a/src/get-started.jade
+++ b/src/get-started.jade
@@ -75,21 +75,21 @@ block content
               | involves configuring the infrastructure and installing DC/OS bits on top, so the infrastructure provider you choose determines your installation method.
 
         .mxn2.flex.flex-auto.flex-wrap.flex-start
-          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.8/administration/installing/cloud/" style="justify-content: inherit; padding-bottom: 2.45rem;")
+          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.9/administration/installing/cloud/" style="justify-content: inherit; padding-bottom: 2.45rem;")
             img.hero-list__item__image(src="/assets/images/icons/cloud.svg")
             h4 Cloud
             p.hero-list__item__copy__paragraph.small.pb3 The easiest option. Automatically configure your infrastructure and install DC/OS with a few clicks or commands.
             .flex.flex-end.mt-auto(style='width: 100%')
               span(href='/get-started', style='width: 100%;').btn.btn-primary.center Install in the cloud
 
-          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.8/administration/installing/local/" style="justify-content: inherit; padding-bottom: 2.45rem;")
+          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.9/administration/installing/local/" style="justify-content: inherit; padding-bottom: 2.45rem;")
             img.hero-list__item__image(src="/assets/images/icons/local.svg")
             h4 Local
             p.hero-list__item__copy__paragraph.small.pb3 The cheapest option, with limited functionality. Run DC/OS on a Vagrant cluster on your machine.
             .flex.flex-end.mt-auto(style='width: 100%')
               span(href='/get-started', style='width: 100%;').btn.btn-primary.center Install locally
 
-          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.8/administration/installing/custom/system-requirements/" style="justify-content: inherit; padding-bottom: 2.45rem;")
+          a.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-white.relative(href="https://dcos.io/docs/1.9/administration/installing/custom/system-requirements/" style="justify-content: inherit; padding-bottom: 2.45rem;")
             img.hero-list__item__image(src="/assets/images/icons/on-premesis.svg")
             h4 On-premises
             p.hero-list__item__copy__paragraph.small.pb3 The most nuanced option. Control everything about your installation. The other install methods are automated versions of this process.
@@ -110,7 +110,7 @@ block content
 
       .max-width-4.mx-auto.pb4
         .mxn2.flex.flex-auto.flex-wrap
-          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/1.8/overview/')
+          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/1.9/overview/')
             p.mb2.mt0 Read the documentation's overview of DC/OS for a conceptual description of DC/OS's inner workings.
             span(style='color: #9351E5') Read the overview
 


### PR DESCRIPTION
Update all links, with the exception of the 101 tutorial which has not yet been
updated for 1.9, so only exists in the 1.8 docs.

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
