### PR TITLE
Docs version redirect fix

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -189,7 +189,7 @@ $('#submit-feedback').attr('href', `https://jira.dcos.io/secure/CreateIssueDetai
 const currentUrlPath = window.location.pathname
 var pathArray = currentUrlPath.split('/')
 
-$('button.dropdown a.option').click(function(event){
+$('.dropdown a.option').click(function(event){
   event.preventDefault()
   pathArray[2] = $(this).attr('data-version')
   var newUrlPath = window.location.origin + pathArray.join('/')


### PR DESCRIPTION
Hi @judithpatudith,

This pull request should fix the issue when switching between versions in the docs.

## Description
https://jira.mesosphere.com/browse/DCOS_SITE-126

## Urgency
- [ ] Blocker <!-- Ping @emanic, @sascala or @joel-hamill for review -->
- [ ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).