### PR TITLE
update-brand-guidelines-link

### DIFF
--- a/redirect-files
+++ b/redirect-files
@@ -1,6 +1,6 @@
 /blog/2016/dc-os-1-8-is-now-available/index.html /blog/2016/dc-os-1-8-early-access/
 /brand /brand/
-/brand/index.html https://brand.ai/mesosphere/dc-os-brand-guidelines
+/brand/index.html https://brand.ai/mesosphere/mesosphere-brand-guidelines
 /docs /docs/latest/
 /docs/ /docs/latest/
 /docs/1.7/administration/dcosarchitecture/security/index.html /docs/1.7/overview/


### PR DESCRIPTION
## Description
I've updated the brand guidelines link to point at the mesosphere brand guidelines link. The DC/OS logos now live on https://brand.ai/mesosphere/mesosphere-brand-guidelines
