### PR TITLE
Remove reference to GitHub stars in our header

### DIFF
--- a/mixins/header-docs.jade
+++ b/mixins/header-docs.jade
@@ -36,9 +36,6 @@ mixin header()
         li.menu-item
           a(href='/blog/') Blog
 
-        li.menu-item
-          a(href='https://github.com/dcos/dcos', target='_blank') GitHub
-
     ul.menu
       li.menu-item
         a(href='/install/') Install
@@ -60,6 +57,3 @@ mixin header()
           a(href='/blog/').active Blog
         else
           a(href='/blog/') Blog
-      li.menu-item
-        .menu-item__github-button
-          a.github-button(href='https://github.com/dcos/dcos', data-count-href='/dcos/dcos/stargazers', data-count-api='/repos/dcos/dcos#stargazers_count', data-count-aria-label='# stargazers on GitHub', aria-label='Star dcos/dcos on GitHub') Star

--- a/mixins/header.jade
+++ b/mixins/header.jade
@@ -52,9 +52,6 @@ mixin header(lightHeader)
         else
           a(href='/blog/') Blog
 
-      li.menu-item
-        a(href='https://github.com/dcos/dcos', target='_blank') GitHub
-
     ul.menu
       li.menu-item
         if(locals.filename === 'install.html')
@@ -94,7 +91,3 @@ mixin header(lightHeader)
           a(href='/blog/').active Blog
         else
           a(href='/blog/') Blog
-
-      li.menu-item
-        .menu-item__github-button
-          a.github-button(href='https://github.com/dcos/dcos', data-count-href='/dcos/dcos/stargazers', data-count-api='/repos/dcos/dcos#stargazers_count', data-count-aria-label='# stargazers on GitHub', aria-label='Star dcos/dcos on GitHub') Star


### PR DESCRIPTION
We link to the GitHub organization clearly elsewhere and are seeking to make
more space for the universe browser in the header.

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
