### PR TITLE
Versions according to --version

### DIFF
--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -28,7 +28,7 @@ block content
           .release-card.release-rc.col.col-12.md-col-6.relative.mb2.md-pl1
             .bg-white.center.inner.px3.py1
               h3.mb0 Early Access
-              p.release-version.pb0 1.10-beta2
+              p.release-version.pb0 1.10.0-beta2
                 a.block.release-notes.mb2(href='/releases/1.10-beta2') Release Notes
 
                 div.download-buttons.mb2
@@ -39,7 +39,7 @@ block content
           .release-card.release-snapshot.col.col-12.md-col-6.relative.md-pl1
             .bg-white.center.inner.px3.py1
               h3.mb0 Master
-              p.release-version.pb0 DC/OS 1.10-snapshot
+              p.release-version.pb0 DC/OS 1.10-dev
 
               div.download-buttons.mb2
                 a.mx1(href='https://downloads.dcos.io/dcos/testing/master/aws.html', target='_blank') Amazon


### PR DESCRIPTION
Fixing version names to be exactly what outputted by `bash dcos_generate_config.sh --version`