### PR TITLE
links to docs should use latest consistently instead of hard-coded ve…

### DIFF
--- a/src/install.jade
+++ b/src/install.jade
@@ -101,7 +101,7 @@ block content
               li Investigating/debugging common problems
 
           .col-12.px2.pt2.center
-            a(href='/docs/1.9/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
+            a(href='/docs/latest/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
 
 
 
@@ -116,7 +116,7 @@ block content
 
       .max-width-4.mx-auto.pb4
         .mxn2.flex.flex-auto.flex-wrap
-          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/1.9/overview/')
+          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/latest/overview/')
             h4 Documentation
             p.mb2.mt0 Read the documentation's overview of DC/OS for a conceptual description of DC/OS's inner workings.
             span(style='color: #7D58FF') Read the docs


### PR DESCRIPTION
…rsion.

## Description
Some links to docs are currently pointing to 1.9. Others point to latest.  They should point to latest consistently.

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [x ] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
