### PR TITLE
Redirect TLS pages to security section

### DIFF
--- a/redirect-files
+++ b/redirect-files
@@ -94,6 +94,8 @@
 /docs/1.10/debugging/cli-debugging/task-exec/quickstart/index.html /docs/1.10/monitoring/debugging/cli-debugging/task-exec/
 /docs/1.10/development/index.html /docs/1.10/developing-services/
 /docs/1.10/monitoring/debugging/cli-debugging/task-exec/index.html /docs/1.10/monitoring/debugging/task-exec/
+/docs/1.10/networking/tls-ssl/index.html /docs/1.10/security/tls-ssl/
+/docs/1.10/networking/tls-ssl/haproxy-adminrouter.html /docs/1.10/security/tls-ssl/haproxy-adminrouter/
 /docs/1.10/overview/components/index.html /docs/1.10/overview/architecture/components/
 /docs/1.10/overview/roadmap/index.html /docs/1.10/
 /docs/1.10/usage/cli/command-reference/dcos-auth/dcos-auth-list-providers/index.html /docs/1.10/cli/command-reference/dcos-auth/dcos-auth-list-providers/


### PR DESCRIPTION
## Description
Do not merge until https://github.com/dcos/dcos-docs/pull/1234 goes through

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [X] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).