### PR TITLE
Point to IoT Pipeline tutorial to 1.9 docs

### DIFF
--- a/src/tutorials.json
+++ b/src/tutorials.json
@@ -43,13 +43,12 @@
     "featured": false,
     "title": "Building an IoT Pipeline",
     "description": "Deploy a containerized Ruby on Rails app, and analyze the data it produces.",
-    "dcos_version": ["1.8","1.9","1.10"],
+    "dcos_version": ["1.8","1.9"],
     "difficulty": "Intermediate",
-    "tutorial" : "/docs/latest/tutorials/iot_pipeline/",
+    "tutorial" : "/docs/1.9/tutorials/iot_pipeline/",
     "callouts": {
       "1.8": "/docs/1.8/usage/tutorials/iot_pipeline/",
-      "1.9": "/docs/1.9/tutorials/iot_pipeline/",
-      "1.10": "/docs/1.10/tutorials/iot_pipeline/"
+      "1.9": "/docs/1.9/tutorials/iot_pipeline/"
     }
   },
   {


### PR DESCRIPTION
The IoT Pipeline tutorial was not updated for 1.10, adjust link to
point to 1.9 and remove 1.10 tag.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [X] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
