### PR TITLE
Removing extra '/' for redirects

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -532,7 +532,7 @@ gulp.task('s3-config', (done) => {
       // redirect all docs paths to new site @ docs.mesosphere.com/
       routingRules.push({
         "Condition": { "KeyPrefixEquals": "docs/" },
-        "Redirect": { "HostName": "docs.mesosphere.com", "ReplaceKeyPrefixWith": "/" }
+        "Redirect": { "HostName": "docs.mesosphere.com", "ReplaceKeyPrefixWith": "" }
       })
       return {
         "IndexDocument": {


### PR DESCRIPTION
Currently `dcos.io/docs` redirects to `https://docs.mesosphere.com//1.10/` instead of `https://docs.mesosphere.com/1.10/`. This should be fixed by just removing the extra `/` in `"ReplaceKeyPrefixWith"`.