### PR TITLE
Fix up documentation links on install page

### DIFF
--- a/src/install.jade
+++ b/src/install.jade
@@ -52,7 +52,7 @@ block content
             h4 Cloud
             p.hero-list__item__copy__paragraph.small(style='min-height: 7rem;')
               | The easiest option. Automatically configure your infrastructure and install DC/OS with a few clicks or commands.
-            a(href='https://dcos.io/docs/latest/installing/cloud/' style='color: #7D58FF') Documentation
+            a(href='https://docs.mesosphere.com/latest/installing/oss/cloud/' style='color: #7D58FF') Documentation
             .flex.flex-end.mt-auto(style='width: 100%')
               div.dropdown.z-500(style='text-align: left; left: 0; width: 100%; position: relative;')
                 a.btn.btn-primary.mb0.block.center.no-arrow.text-white.bg-heliotrope Install in the cloud
@@ -66,7 +66,7 @@ block content
             h4 On-premises
             p.hero-list__item__copy__paragraph.small(style='min-height: 7rem;')
               | The most flexible option. Control everything about your installation. The other install methods are automated versions of this process.
-            a(href='https://dcos.io/docs/latest/installing/custom/' style='color: #7D58FF') Documentation
+            a(href='https://docs.mesosphere.com/latest/installing/oss/custom/' style='color: #7D58FF') Documentation
             .flex.flex-end.mt-auto(style='width: 100%')
               a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh', style='width: 100%;').btn.btn-primary.center.m0 Install on premises
 
@@ -102,7 +102,7 @@ block content
               li Investigating/debugging common problems
 
           .col-12.px2.pt2.center
-            a(href='/docs/latest/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
+            a(href='https://docs.mesosphere.com/latest/tutorials/dcos-101/', style='width: 100%;').btn.btn-primary Start the 101 Tutorial
 
 
 
@@ -117,7 +117,7 @@ block content
 
       .max-width-4.mx-auto.pb4
         .mxn2.flex.flex-auto.flex-wrap
-          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/latest/overview/')
+          a.card.col-4.left-align.px3.py3(style='display: block' href='https://docs.mesosphere.com/latest/overview/')
             h4 Documentation
             p.mb2.mt0 Read the documentation's overview of DC/OS for a conceptual description of DC/OS's inner workings.
             span(style='color: #7D58FF') Read the docs
@@ -127,7 +127,7 @@ block content
             p.mb2.mt0 Get help via mailing list, Slack, or Stack Overflow by joining the DC/OS community.
             span(style='color: #7D58FF') Join the community
 
-          a.card.col-4.left-align.px3.py3(style='display: block' href='/docs/latest/tutorials/')
+          a.card.col-4.left-align.px3.py3(style='display: block' href='https://docs.mesosphere.com/latest/tutorials/')
              h4 Tutorials
              p.mb2.mt0 Tutorials are hands-on walkthroughs of DC/OS with explanations.
              span(style='color: #7D58FF') Try a tutorial


### PR DESCRIPTION
We don't want to rely upon the old documentation redirects
for our main site, update for new docs site.

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
