### PR TITLE
Add code of conduct page

### DIFF
--- a/mixins/footer-docs.jade
+++ b/mixins/footer-docs.jade
@@ -8,7 +8,7 @@ mixin footer()
           li.footer-item
             a(href='/contribute/') Contribute
           li.footer-item
-            a(href='/tos/') Terms&nbsp;of&nbsp;Service
+            a(href='/coc/') Code&nbsp;of&nbsp;Conduct
           li.footer-item
             a(href='/privacy/') Privacy&nbsp;Policy
           li.footer-item
@@ -33,9 +33,9 @@ mixin footer()
             a(href='https://jira.mesosphere.com')
               img.footer-item__icon(src='/assets/images/icons/jira-dark.svg')
               span Jira
-      .footer__copyright-wrap(style='font-size: 12px;')        
-        ul.footer-third      
-          li.footer-item 
-            a(href='https://mesosphere.com') DC/OS is backed by Mesosphere, Inc.
+      .footer__copyright-wrap(style='font-size: 12px;')
+        ul.footer-third
+          li.footer-item
+            a(href='https://mesosphere.com') DC/OS is backed by Mesosphere, Inc. #[a(href='/tos/') Terms&nbsp;of&nbsp;Service]
 
   +libraries

--- a/mixins/footer.jade
+++ b/mixins/footer.jade
@@ -8,7 +8,7 @@ mixin footer()
           li.footer-item
             a(href='/contribute/') Contribute
           li.footer-item
-            a(href='/tos/') Terms&nbsp;of&nbsp;Service
+            a(href='/coc/') Code&nbsp;of&nbsp;Conduct
           li.footer-item
             a(href='/privacy/') Privacy&nbsp;Policy
           li.footer-item
@@ -33,9 +33,9 @@ mixin footer()
             a(href='https://jira.mesosphere.com')
               img.footer-item__icon(src='/assets/images/icons/jira.svg')
               span Jira
-      .footer__copyright-wrap(style='font-size: 12px;')        
-        ul.footer-third      
+      .footer__copyright-wrap(style='font-size: 12px;')
+        ul.footer-third
           li.footer-item
-            a(href='https://mesosphere.com') DC/OS is backed by Mesosphere, Inc. 
+            a(href='https://mesosphere.com') DC/OS is backed by Mesosphere, Inc. #[a(href='/tos/') Terms&nbsp;of&nbsp;Service] 
 
   +libraries

--- a/src/coc.jade
+++ b/src/coc.jade
@@ -1,0 +1,21 @@
+extends ../layouts/base-whitefooter.jade
+
+block head
+  title DC/OS
+
+block content
+
+  .container.container--dark-background
+    +header
+
+    .container__content
+      h1 Code of Conduct
+      p.hero-subtitle Keep our community welcoming and inclusive.
+
+  .container
+    .container__content
+      .text-align-left
+        include:markdown coc.md
+
+  .container
+      +footer

--- a/src/coc.md
+++ b/src/coc.md
@@ -1,0 +1,63 @@
+
+The Mesosphere DC/OS community is made up of users and contributors from around the world who collaborate in chat, on mailing lists, at events, and on other channels to help each other get the most out of DC/OS.
+
+Everyone you encounter in chat or on the mailing list is contributing voluntarily and helps on a best-effort basis, including Mesosphere employees. Treating everyone in the project with respect is essential to make sure members of our community feel welcome and encouraged to participate in the future. Please be kind and patient with your fellow community members.
+
+Additionally DC/OS has a code of conduct that participants are expected to adhere to in order to make sure that no one is discriminated against or excluded because of their identity.
+
+Breaches of the code of conduct and inappropriate behavior are handled on a case by case basis, but the consequences for violating it may include limiting or removing your ability to collaborate on project resources and at events.
+
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+### Our Standards
+
+#### Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language.
+
+* Being respectful of differing viewpoints and experiences.
+
+* Gracefully accepting constructive criticism.
+
+* Focusing on what is best for the community.
+
+* Showing empathy towards other community members.
+
+#### Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances.
+
+* Trolling, insulting/derogatory comments, and personal or political attacks.
+
+* Public or private harassment.
+
+* Publishing others’ private information, such as a physical or electronic
+address, without explicit permission.
+
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting.
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [community-team@dcos.io](mailto:community-team@dcos.io). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good  faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)


### PR DESCRIPTION
Adding code of conduct page and menu items on both purple and white footers

## Description
<!-- Link to JIRA issue -->

## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [ ] High
- [x] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
