### PR TITLE
changing master label to 1.12-dev

### DIFF
--- a/src/releases/index.jade
+++ b/src/releases/index.jade
@@ -39,7 +39,7 @@ block content
           .release-card.release-snapshot.col.col-12.md-col-6.relative.md-pl1
             .bg-white.center.inner.px3.py1
               h3.mb0 Master
-              p.release-version.pb0 DC/OS 1.11-dev
+              p.release-version.pb0 DC/OS 1.12-dev
 
               div.download-buttons.mb2
                 a.mx1(href='https://downloads.dcos.io/dcos/testing/master/aws.html', target='_blank') Amazon


### PR DESCRIPTION
## Description
Changing the label for the master channel to 1.12 dev now that 1.11 has branched off. 
## Urgency
- [ ] Blocker <!-- Ping @sascala or @joel-hamill for review -->
- [x] High
- [ ] Medium

## Requirements
- Test all commands and procedures.
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
- Add redirects to [dcos-website/redirect-files](https://github.com/dcos/dcos-website#managing-redirects).
- Change all affected versions (e.g. 1.7, 1.8, and 1.9).
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
