### PR TITLE
Updating latest to point to 1.11 docs

### DIFF
--- a/redirect-prefixes
+++ b/redirect-prefixes
@@ -1,4 +1,4 @@
-/docs/latest/ /docs/1.10/
+/docs/latest/ /docs/1.11/
 /documentation/ /docs/latest/
 /support/ /community/
 /docs/overview/ /docs/latest/overview/


### PR DESCRIPTION
Since 1.11 is the latest release, updating `latest` to point to the `1.11` documentation.