### PR TITLE
Fix the website build process, and remove the deprecated submodule to build the docs in the tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "dcos-docs"]
-	path = dcos-docs
-	url = https://github.com/dcos/dcos-docs.git

--- a/build-artifacts/Dockerfile
+++ b/build-artifacts/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:7.1.0-slim
+
+RUN apt-get update && apt-get install -y \
+    git \
+    python \
+    build-essential \
+    rsync \
+    inotify-tools \
+ && rm -rf /var/lib/apt/lists/*

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -5,7 +5,7 @@ if [ ! -d tmp/node_modules ]; then
 fi
 
 if ! docker images | grep docs-runner; then
-  docker build -f dcos-docs/Dockerfile -t docs-runner .
+  docker build -f build-artifacts/Dockerfile -t docs-runner .
 fi
 
 docker run -it -p 3000:3000 -p 3001:3001 -v $PWD:/website \


### PR DESCRIPTION
## Description
https://jira.mesosphere.com/browse/OSS-1311

## Urgency
- [ ] Blocker <!-- Ping @judithpatudith for review -->
- [ ] High
- [x] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
