### PR TITLE
Remove duplicate 2018-07-05 event

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -965,12 +965,6 @@
       "url": "/events/2018/edinburgh-devops-introduction-to-dc-os"
   },
 
-  { "title": "Introduction to DC/OS (Meetup)",
-      "image": "/assets/images/events/Edinburgh.jpg",
-      "date": "2018-07-05",
-      "url": "https://www.meetup.com/Edinburgh-DevOps-Meetup/events/248991957/"
-  },
-
   { "title": "SMACK Stack on DC/OS using Cloud Infrastructure (OSCON)",
       "image": "/assets/images/events/Portland.jpg",
       "date": "2018-07-17",


### PR DESCRIPTION
Looks like git wasn't perfectly clever when it resolved some changes
between commits, ended up with 2 cards for the 2018-07-05 event.

Removing the old one.

## Urgency
- [x] Blocker <!-- Tag @pleia2 & @mattj-io for review -->
- [ ] High
- [ ] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
