### PR TITLE
Update PoC wording and docs links on install page

### DIFF
--- a/src/install.jade
+++ b/src/install.jade
@@ -49,10 +49,10 @@ block content
 
           div.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-gray.relative(style="justify-content: inherit; padding-bottom: 2.45rem")
             img.hero-list__item__image(src="/assets/images/icons/cloud.svg")
-            h4 Proof of Concept
+            h4 Evaluation
             p.hero-list__item__copy__paragraph.small(style='min-height: 7rem;')
-              | Deploy DC/OS using public cloud templates, for fast demos and POCs. Install DC/OS with a few clicks or commands. (limited functionality)
-            a(href='https://docs.mesosphere.com/latest/installing/oss/cloud/' style='color: #7D58FF') Documentation
+              | Deploy DC/OS using public cloud templates, for fast demos and evaluations. Install DC/OS with a few clicks or commands. (limited functionality)
+            a(href='https://docs.mesosphere.com/latest/installing/evaluation/cloud-installation/' style='color: #7D58FF') Documentation
             .flex.flex-end.mt-auto(style='width: 100%')
               div.dropdown.z-500(style='text-align: left; left: 0; width: 100%; position: relative;')
                 a.btn.btn-primary.mb0.block.center.no-arrow.text-white.bg-heliotrope Cloud templates
@@ -60,14 +60,14 @@ block content
                 ul
                   li: a(href='https://downloads.dcos.io/dcos/stable/aws.html', target='_blank') Amazon Web Services
                   li: a(href='https://downloads.dcos.io/dcos/stable/azure.html', target='_blank') Azure
-                  li: a(href='https://docs.mesosphere.com/latest/installing/oss/cloud/gce/', target='_blank') Google Cloud Platform
+                  li: a(href='https://docs.mesosphere.com/latest/installing/evaluation/cloud-installation/gce/', target='_blank') Google Cloud Platform
 
           div.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-gray.relative(style="justify-content: inherit; padding-bottom: 2.45rem")
             img.hero-list__item__image(src="/assets/images/icons/on-premesis.svg")
             h4 Production
             p.hero-list__item__copy__paragraph.small(style='min-height: 7rem;')
               | Follow the advanced installation instructions to create production ready DC/OS clusters on any infrastructure. (full functionality)
-            a(href='https://docs.mesosphere.com/latest/installing/oss/custom/advanced/' style='color: #7D58FF') Documentation
+            a(href='https://docs.mesosphere.com/latest/installing/production/deploying-dcos/installation/' style='color: #7D58FF') Documentation
             .flex.flex-end.mt-auto(style='width: 100%')
               a(href='https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh', style='width: 100%;').btn.btn-primary.center.m0 Download DC/OS
 


### PR DESCRIPTION
Now that the new documentation structure has gone live, update the
"Proof of Concept" language on the install page to instead say
"Evaluation" and adjust the documentation links so they reflect
the new structure, and aren't pointing at URLs which are now
being redirected.

## Description
https://jira.mesosphere.com/browse/DCOS_OSS-3912

## Urgency
- [ ] Blocker <!-- Tag @pleia2 & @mattj-io for review -->
- [x] High
- [ ] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
