### PR TITLE
Add "Coming soon" to 1.12.0-beta1 features section

### DIFF
--- a/src/releases.json
+++ b/src/releases.json
@@ -3,6 +3,9 @@
     "title": "DC/OS 1.12 Beta1",
     "date": "2018-09-20",
     "description": "DC/OS 1.12 beta releases are for testing only and should not be run in production. Please feel free to explore the beta release, and file any issues you find in Jira. Your help looking for bugs is much appreciated!",
+    "features": [
+      "Details coming soon."
+    ],
     "downloadlink": {
       "amazon": "https://downloads.dcos.io/dcos/EarlyAccess/",
       "azure": "https://downloads.dcos.io/dcos/EarlyAccess/azure.html",


### PR DESCRIPTION
The site renders a "Features" heading even when we haven't added them yet. Just put
in a coming soon placeholder

## Urgency
- [x] Blocker <!-- Tag @pleia2 & @mattj-io for review -->
- [ ] High
- [ ] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
