### PR TITLE
Deprecate dcos-vagrant

### DIFF
--- a/src/install.jade
+++ b/src/install.jade
@@ -43,9 +43,9 @@ block content
             img.hero-list__item__image(src="/assets/images/icons/local.svg")
             h4 Development
             p.hero-list__item__copy__paragraph.small(style='min-height: 7rem;')
-              |Try DC/OS by installing a dcos-vagrant cluster on your local machine. Room for workloads is limited by CPU and memory. (limited functionality)
+              |Try DC/OS by installing a mini-DCOS cluster using Vagrant, Docker or AWS. Room for workloads is limited by CPU and memory. (limited functionality)
             .flex.flex-end.mt-auto(style='width: 100%')
-            a(href='https://github.com/dcos/dcos-vagrant', style='width: 100%;').btn.btn-primary.center.m0 Local installation
+            a(href='https://minidcos.readthedocs.io/en/latest/index.html', style='width: 100%;').btn.btn-primary.center.m0 miniDC/OS installation
 
           div.lg-col-4.col-6.xs-col-12.xs-center.px3.py3.center.card.bg-gray.relative(style="justify-content: inherit; padding-bottom: 2.45rem")
             img.hero-list__item__image(src="/assets/images/icons/cloud.svg")


### PR DESCRIPTION
## Description
Deprecate dcos-vagrant in favor of minidcos

## Urgency
- [ ] Blocker <!-- Tag @pleia2 & @mattj-io for review -->
- [ ] High
- [ ] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
