### PR TITLE
1.10.11 release (CVE-2019-5736)

### DIFF
--- a/src/releases.json
+++ b/src/releases.json
@@ -77,11 +77,12 @@
       "Marathon 1.5."
     ],
     "downloadlink": {
-      "amazon": "https://downloads.dcos.io/dcos/stable/1.10.10/aws.html",
-      "azure": "https://downloads.dcos.io/dcos/stable/1.10.10/azure.html",
-      "direct": "https://downloads.dcos.io/dcos/stable/1.10.10/dcos_generate_config.sh"
+      "amazon": "https://downloads.dcos.io/dcos/stable/1.10.11/aws.html",
+      "azure": "https://downloads.dcos.io/dcos/stable/1.10.11/azure.html",
+      "direct": "https://downloads.dcos.io/dcos/stable/1.10.11/dcos_generate_config.sh"
     },
     "subreleases": [
+      { "name": "1.10.11", "url": "https://docs.mesosphere.com/1.10/release-notes/1.10.11/"},
       { "name": "1.10.10", "url": "https://docs.mesosphere.com/1.10/release-notes/1.10.10/"},
       { "name": "1.10.9", "url": "https://docs.mesosphere.com/1.10/release-notes/1.10.9/"},
       { "name": "1.10.8", "url": "https://docs.mesosphere.com/1.10/release-notes/1.10.8/"},


### PR DESCRIPTION
## Description
Bump point release of 1.10 which includes fixes for CVE-2019-5736.

## Urgency
- [ ] Blocker
- [X] High
- [ ] Medium