### PR TITLE
Update dcos-runner base image

### DIFF
--- a/build-artifacts/Dockerfile
+++ b/build-artifacts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.1.0-slim
+FROM node:8.16.0-jessie-slim
 
 RUN apt-get update && apt-get install -y \
     git \


### PR DESCRIPTION
## Description

The base node image used to build dcos-runner is super old and causes problems during the build stage.  This commit updates this base image to a newer release.

## Urgency
- [ ] Blocker
- [ ] High
- [X] Medium
