### PR TITLE
Update links for 1.12.4 release

### DIFF
--- a/src/releases.json
+++ b/src/releases.json
@@ -40,11 +40,12 @@
       "UI/UX Enhancements with over 100+ bug fixes"
     ],
     "downloadlink": {
-      "amazon": "https://downloads.dcos.io/dcos/stable/1.12.3/aws.html",
-      "azure": "https://downloads.dcos.io/dcos/stable/1.12.3/azure.html",
-      "direct": "https://downloads.dcos.io/dcos/stable/1.12.3/dcos_generate_config.sh"
+      "amazon": "https://downloads.dcos.io/dcos/stable/1.12.4/aws.html",
+      "azure": "https://downloads.dcos.io/dcos/stable/1.12.4/azure.html",
+      "direct": "https://downloads.dcos.io/dcos/stable/1.12.4/dcos_generate_config.sh"
     },
     "subreleases": [
+      { "name": "1.12.4", "url": "https://docs.mesosphere.com/1.12/release-notes/1.12.4/"},
       { "name": "1.12.3", "url": "https://docs.mesosphere.com/1.12/release-notes/1.12.3/"},
       { "name": "1.12.2", "url": "https://docs.mesosphere.com/1.12/release-notes/1.12.2/"},
       { "name": "1.12.1", "url": "https://docs.mesosphere.com/1.12/release-notes/1.12.1/"},


### PR DESCRIPTION
## Description
This commit updates links and download URIs for the 1.12.4 release of DC/OS.

## Urgency
- [ ] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [X] Medium