### PR TITLE
Fix link for OSAD 2019 talk

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -1177,8 +1177,8 @@
   
   { "title": "From Batch to Pipelines (Open Source Automation Days Munich)",
       "image": "/assets/images/events/Munich.jpg",
-      "date": "2019-10-15",
-      "url": "https://osad-munich.org/from-batch-to-pipelines-why-apache-mesos-and-dc-os-are-a-solution-for-emerging-patterns-in-cloud-native-apps/"
+      "date": "2019-10-16",
+      "url": "https://osad-munich.org/en/featured-speakers/from-batch-to-pipelines/"
   },
 
   { "title": "",


### PR DESCRIPTION
## Description
The link to the [OSAD](https://osad-munich.org/en/) talk currently 404s and so needs updating to point to the correct URL.  Also the date needs updating as this talk is on the second day of the event.

## Urgency
- [ ] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [X] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.