### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Built using [Metalsmith](http://metalsmith.io).
 
 ## License and Authors
 
-Copyright 2017 Mesosphere, Inc.
+Copyright 2019 D2iQ, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this repository except in compliance with the License.

--- a/mixins/header.jade
+++ b/mixins/header.jade
@@ -26,7 +26,7 @@ mixin header(lightHeader)
           a(href='/releases/') Releases
 
       li.menu-item
-        a(href='https://docs.mesosphere.com/latest/') Documentation
+        a(href='https://docs.d2iq.com/mesosphere/dcos/latest') Documentation
 
       li.menu-item
         if(locals.filename === 'demos.html')


### PR DESCRIPTION
## Description
The burger menu documentation link points to the wrong address.  This is
manifest when a user is browsing from a mobile device.

## Urgency
- [X] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [ ] Medium

