### PR TITLE
DC/OS 1.13.6 release

### DIFF
--- a/src/releases.json
+++ b/src/releases.json
@@ -40,9 +40,10 @@
       "amazon": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/aws/",
       "azure": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/azure/",
       "google": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/gcp/",
-      "direct": "https://downloads.dcos.io/dcos/stable/1.13.5/dcos_generate_config.sh"
+      "direct": "https://downloads.dcos.io/dcos/stable/1.13.6/dcos_generate_config.sh"
     },
     "subreleases": [
+      { "name": "1.13.6", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.6/"},
       { "name": "1.13.5", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.5/"},
       { "name": "1.13.4", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.4/"},
       { "name": "1.13.3", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.3/"},


### PR DESCRIPTION
## Description
Bump releases page for 1.13.6.

_NB_: Release isn't yet live and so this shouldn't be merged until it's ready.

## Urgency
- [ ] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [X] Medium

