### PR TITLE
Bump version of Node.js used to build website

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6.10.1
+FROM mhart/alpine-node:8.17
 
 RUN apk --no-cache add git curl xz bash python make g++
 


### PR DESCRIPTION
Fix website builds in CI by updating the base website image builder to Node.js 8.17.

## Urgency
- [ ] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [X] Medium

