### PR TITLE
Bump for DC/OS 1.13.8 release

### DIFF
--- a/src/releases.json
+++ b/src/releases.json
@@ -42,9 +42,10 @@
       "amazon": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/aws/",
       "azure": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/azure/",
       "google": "https://docs.d2iq.com/mesosphere/dcos/1.13/installing/evaluation/gcp/",
-      "direct": "https://downloads.dcos.io/dcos/stable/1.13.7/dcos_generate_config.sh"
+      "direct": "https://downloads.dcos.io/dcos/stable/1.13.8/dcos_generate_config.sh"
     },
     "subreleases": [
+      { "name": "1.13.8", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.8/"},
       { "name": "1.13.7", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.7/"},
       { "name": "1.13.6", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.6/"},
       { "name": "1.13.5", "url": "https://docs.d2iq.com/mesosphere/dcos/1.13/release-notes/1.13.5/"},


### PR DESCRIPTION
## Description
Update site for release of DC/OS 1.13.8:  https://jira.d2iq.com/browse/OSS-1675

## Urgency
- [ ] Blocker <!-- Tag @yankcrime & @mattj-io for review -->
- [ ] High
- [X] Medium

## Requirements
- See the [contribution guidelines](https://github.com/dcos/dcos-website#contribution-workflow).
- Build content [locally](https://github.com/dcos/dcos-website#testing-your-updates-locally) and test for formatting/links.
